### PR TITLE
Add warning if `screenshotName` not provided

### DIFF
--- a/src/visual/visual.spec.ts
+++ b/src/visual/visual.spec.ts
@@ -19,7 +19,8 @@ describe('SkyVisual', () => {
 
   beforeEach(() => {
     mockLogger = {
-      info(): void {}
+      info(): void {},
+      warn(): void {}
     };
 
     mockPixDiff = new MockPixDiff();
@@ -147,6 +148,32 @@ describe('SkyVisual', () => {
 
     SkyVisual.compareScreenshot('foo').catch((error: any) => {
       expect(error.message).toEqual('something bad happened');
+      done();
+    });
+  });
+
+  it('should warn the consumer if a screenshot name is not provided', (done) => {
+    const spy = spyOn(mockLogger, 'warn');
+
+    applyMocks();
+
+    SkyVisual.compareScreenshot().then((result: boolean) => {
+      expect(result).toEqual(true);
+      expect(spy).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('should not warn the consumer if a screenshot name is provided', (done) => {
+    const spy = spyOn(mockLogger, 'warn');
+
+    applyMocks();
+
+    SkyVisual.compareScreenshot('foo', {
+      screenshotName: 'foo'
+    }).then((result: boolean) => {
+      expect(result).toEqual(true);
+      expect(spy).not.toHaveBeenCalled();
       done();
     });
   });

--- a/src/visual/visual.ts
+++ b/src/visual/visual.ts
@@ -28,8 +28,8 @@ export abstract class SkyVisual {
 
       logger.warn([
         'A unique screenshot name was not provided!\n',
-        `We'll use "${settings.screenshotName}" as a stand-in, but this can cause your screenshots to be`,
-        'overwritten if the element selectors being tested are the same from one test to another.',
+        `We'll use "${settings.screenshotName}" as a stand-in, but this can cause problems`,
+        'if you decide to change the order of the specs in the future.',
         'To set the screenshot name for each test, add a config object to the matcher:\n',
         '`expect(\'.foobar\').toMatchBaselineScreenshot(done, { screenshotName: \'unique-name\' });`'
       ].join(' '));

--- a/src/visual/visual.ts
+++ b/src/visual/visual.ts
@@ -25,6 +25,14 @@ export abstract class SkyVisual {
         .replace(/\W+(?!$)/g, '-')
         .replace(/\W+$/, '')
         .toLowerCase() + nextUniqueId++;
+
+      logger.warn([
+        'A unique screenshot name was not provided!\n',
+        `We'll use "${settings.screenshotName}" as a stand-in, but this can cause your screenshots to be`,
+        'overwritten if the element selectors being tested are the same from one test to another.',
+        'To set the screenshot name for each test, add a config object to the matcher:\n',
+        '`expect(\'.foobar\').toMatchBaselineScreenshot(done, { screenshotName: \'unique-name\' });`'
+      ].join(' '));
     }
 
     return protractor.browser.pixDiff


### PR DESCRIPTION
- If a screenshot name is not provided to the matcher, `SkyVisual` will create one automatically. The problem is that the screenshot generated depends on an auto-incrementing ID, which will change if specs are added before a given `it` block. There's no way to change this behavior without creating a breaking change, so I created a warning in the console when the `screenshotName` is not set.